### PR TITLE
fix: code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cf.yaml
+++ b/.github/workflows/cf.yaml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: Cloud Foundry
 
 on:
@@ -26,6 +24,9 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
 
 concurrency:
   group: cf-${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/cf.yaml
+++ b/.github/workflows/cf.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Cloud Foundry
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: capire/samples/.github/workflows/test.yaml@main

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/capire/samples/security/code-scanning/4](https://github.com/capire/samples/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow. Since the workflow only checks out code and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow (before the `jobs:` key), which will apply to all jobs in the workflow unless overridden. This change should be made in `.github/workflows/test.yaml`, above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
