### PR TITLE
Fix permissions

### DIFF
--- a/.github/workflows/cf.yaml
+++ b/.github/workflows/cf.yaml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
 
 concurrency:
   group: cf-${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
 
 jobs:
   tests:


### PR DESCRIPTION
Also require `write` permission for deployments in the CF + Release workflows.