### PR TITLE
docs: mention `git submodule init` after cloning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Assumed you did your [initial setup of CAP Node.js](https://cap.cloud.sap/docs/g
 ```sh
 git clone -j11 -q --recursive https://github.com/capire/samples cap/samples
 cd cap/samples
+git submomdule init
 npm run latest
 npm install
 npm test


### PR DESCRIPTION
This is required to get the submodules initialized correctly after first clone