### PR TITLE
chore(ci): fix deployment

### DIFF
--- a/.deploy/app-router/xs-app.json
+++ b/.deploy/app-router/xs-app.json
@@ -14,12 +14,6 @@
       "csrfProtection": true
     },
     {
-      "source": "^/browse/(.*)$",
-      "target": "/browse/$1",
-      "destination": "bookstore-api",
-      "csrfProtection": true
-    },
-    {
       "source": "^/user/(.*)$",
       "target": "/user/$1",
       "destination": "bookstore-api",
@@ -38,8 +32,8 @@
       "csrfProtection": true
     },
     {
-      "source": "^/rest/catalog/(.*)$",
-      "target": "/rest/catalog/$1",
+      "source": "^/rest/browse/(.*)$",
+      "target": "/rest/browse/$1",
       "destination": "bookstore-api",
       "csrfProtection": true
     },

--- a/.github/workflows/cf.yaml
+++ b/.github/workflows/cf.yaml
@@ -1,7 +1,6 @@
 name: Cloud Foundry
 
 on:
-  pull_request:
   workflow_call:
     inputs:
       environment:

--- a/.github/workflows/cf.yaml
+++ b/.github/workflows/cf.yaml
@@ -1,6 +1,7 @@
 name: Cloud Foundry
 
 on:
+  pull_request:
   workflow_call:
     inputs:
       environment:
@@ -40,6 +41,7 @@ jobs:
           username: ${{ vars.CF_USERNAME }}
           password: ${{ secrets.CF_PASSWORD }}
       - run: npm install
+      - run: cd bookstore && npm add @sap-cloud-sdk/http-client@^4
       - run: npx cds up
 
       - run: cf logs ${{ env.APP_NAME }} --recent


### PR DESCRIPTION
- Adjusted approuter routing from `/rest/catalog` to `/rest/browse`.
- Adding `npm add @sap-cloud-sdk/http-client@^4` in the deployment as this is causing deployment errors after https://github.com/capire/bookstore/commit/5a2ccabd2e75568c96cf4af2fdd8d071c48623e3. Will revisit with cds 10.

→ Staging works again (tested in PR)