### PR TITLE
fix: add more required cloud SDK libraries in CI

### DIFF
--- a/.github/workflows/cf.yaml
+++ b/.github/workflows/cf.yaml
@@ -40,7 +40,7 @@ jobs:
           username: ${{ vars.CF_USERNAME }}
           password: ${{ secrets.CF_PASSWORD }}
       - run: npm install
-      - run: cd bookstore && npm add @sap-cloud-sdk/http-client@^4
+      - run: cd bookstore && npm add @sap-cloud-sdk/http-client@^4 @sap-cloud-sdk/connectivity@^4 @sap-cloud-sdk/resilience@^4
       - run: npx cds up
 
       - run: cf logs ${{ env.APP_NAME }} --recent


### PR DESCRIPTION
Required so productive deployment still works E2E with the multiple microservices, otherwise you run into 502 Bad Gateway issues, for example when submitting a book order.