### PR TITLE
feat: prepare `cds-dk` 10.1 simplifications

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -10,9 +10,9 @@ build-parameters:
       commands:
         - npm ci
         - npx cds build shared-db --for hana --production
-        - npx cds build orders --for nodejs --production --ws-pack
+        - npx cds build orders --for nodejs --production
         - npx cds build reviews --for nodejs --production
-        - npx cds build bookstore --for nodejs --production --ws-pack
+        - npx cds build bookstore --for nodejs --production
 modules:
   - name: orders-srv
     type: nodejs
@@ -24,7 +24,7 @@ modules:
       disk-quota: 256M
       memory: 256M
     build-parameters:
-      builder: npm
+      builder: npm-ci
     provides:
       - name: orders-api
         properties:
@@ -45,7 +45,7 @@ modules:
       disk-quota: 256M
       memory: 256M
     build-parameters:
-      builder: npm
+      builder: npm-ci
     provides:
       - name: reviews-api
         properties:
@@ -69,7 +69,7 @@ modules:
       cds_requires_ReviewsService_credentials: {"destination": "reviews-dest","path": "/reviews"}
       cds_requires_OrdersService_credentials: {"destination": "orders-dest","path": "/odata/v4/orders"}
     build-parameters:
-      builder: npm
+      builder: npm-ci
     provides:
       - name: bookstore-api
         properties:


### PR DESCRIPTION
- `cds build` runs `--ws-pack` by default
- `cds up` auto-creates missing `package-lock.json` in microservices by copying the root one